### PR TITLE
Add `asyncIt` to move away from checking test promise errors in afterEach

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
   * [mouseDown](#mousedown)
   * [mouseUp](#mouseup)
   * [mouseMove](#mousemove)
+  * [touchStart](#touchstart)
+  * [touchMove](#touchmove)
+  * [touchCancel](#touchcancel)
+  * [touchEnd](#touchend)
   * [fillIn](#fillin)
   * [keyEventIn](#keyeventin)
   * [waitUntilExists](#waituntilexists)
@@ -23,6 +27,7 @@
   * [find](#find)
   * [jQuery](#jquery)
   * [setupAsync](#setupasync)
+  * [asyncIt](#asyncit)
   * [andThen](#andthen)
   * [waitUntil](#waituntil)
   * [waitMillis](#waitmillis)
@@ -95,6 +100,7 @@ For testing with Mocha. Currently only runs in browsers, see
 ```js
 import {
   setupAndTeardownApp,
+  asyncIt,
   startFakingXhr,
   stopFakingXhr,
   visit,
@@ -112,7 +118,7 @@ describe('my app', () => {
   setupAndTeardownApp(renderMyApp, createMemoryHistory);
 
   describe('with basic acceptance testing', () => {
-    it('shows greeting when I click the hello button on the say-hello page', () => {
+    asyncIt('shows greeting when I click the hello button on the say-hello page', () => {
       visit('/say-hello');
 
       click('.hello-button'); // This will wait for the button to show up, and then click it. Any jQuery selector will work.
@@ -130,7 +136,7 @@ describe('my app', () => {
     beforeEach(startFakingXhr);
     afterEach(stopFakingXhr);
 
-    it('displays the number of eggs we currently have on the server (using regular XHR)', () => {
+    asyncIt('displays the number of eggs we currently have on the server (using regular XHR)', () => {
       visit('/eggs');
 
       waitUntilXhrExists('GET', '/api/v1/eggs');
@@ -149,7 +155,7 @@ describe('my app', () => {
   describe('with fake fetch', () => {
     setupFakeFetchAsync();
 
-    it('shows the color of the day (using Fetch API)', () => {
+    asyncIt('shows the color of the day (using Fetch API)', () => {
       visit('/color');
 
       waitUntilFetchExists('/api/v1/color');
@@ -272,6 +278,70 @@ Waits for an element to show up, and then simulates a user mouse move by trigger
 mouseDown('.element-to-mouse-move-on', { clientX: 1337, clientY: 1338 });
 ```
 
+### touchStart
+
+Waits for an element to show up, and then simulates a user touch start by triggering a touch event on that element.
+
+**Parameters**
+
+-   `selector` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [jQuery](#jquery))** The jQuery selector or jQuery object to simulate touch on.
+    Note that the selector or jQuery object must represent exactly one (1) element in the app, or the call will fail.
+-   `options` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Any options to pass along to the simulated touch event.
+
+**Examples**
+
+```javascript
+touchStart('.element-to-touch', {touches: [{ clientX: 1337, clientY: 1338 }], changedTouches: [{ clientX: 1337, clientY: 1338}]});
+```
+
+### touchMove
+
+Waits for an element to show up, and then simulates a user touch move by triggering a touch event on that element.
+
+**Parameters**
+
+-   `selector` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [jQuery](#jquery))** The jQuery selector or jQuery object to simulate touch on.
+    Note that the selector or jQuery object must represent exactly one (1) element in the app, or the call will fail.
+-   `options` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Any options to pass along to the simulated touch event.
+
+**Examples**
+
+```javascript
+touchMove('.element-to-touch', {touches: [{ clientX: 1337, clientY: 1338 }], changedTouches: [{ clientX: 1337, clientY: 1338}]});
+```
+
+### touchCancel
+
+Waits for an element to show up, and then simulates a user touch cancel by triggering a touch event on that element.
+
+**Parameters**
+
+-   `selector` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [jQuery](#jquery))** The jQuery selector or jQuery object to simulate touch on.
+    Note that the selector or jQuery object must represent exactly one (1) element in the app, or the call will fail.
+-   `options` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Any options to pass along to the simulated touch event.
+
+**Examples**
+
+```javascript
+touchCancel('.element-to-touch', {touches: [{ clientX: 1337, clientY: 1338 }], changedTouches: [{ clientX: 1337, clientY: 1338}]});
+```
+
+### touchEnd
+
+Waits for an element to show up, and then simulates a user touch end by triggering a touch event on that element.
+
+**Parameters**
+
+-   `selector` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [jQuery](#jquery))** The jQuery selector or jQuery object to simulate touch on.
+    Note that the selector or jQuery object must represent exactly one (1) element in the app, or the call will fail.
+-   `options` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Any options to pass along to the simulated touch event.
+
+**Examples**
+
+```javascript
+touchEnd('.element-to-touch', {touches: [{ clientX: 1337, clientY: 1338 }], changedTouches: [{ clientX: 1337, clientY: 1338}]});
+```
+
 ### fillIn
 
 Waits for an input element to show up, and then simulates a user filling in the value of that input.
@@ -348,6 +418,13 @@ Simply the jQuery constructor.
 Sets up the async test tools by adding the appropriate calls to `beforeEach` and `afterEach`.
 Call once in the top of a `describe` that you wish to use the async tools in.
 NOTE: When using [setupAndTeardownApp](#setupandteardownapp), it is not necessary to call this function separately.
+
+### asyncIt
+
+Drop-in replacement for the regular `it` function, with the same signature.
+This will augments the `it` functionality to automatically return the global test promise behind the scenes, to make
+the asynchronous helpers work as expected without any need for the developer to return a promise or call a `done` function.
+The `done` parameter can still be used and will override the global test promise flow as per the default mocha behavior.
 
 ### andThen
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For testing with Mocha. Currently only runs in browsers, see
 ```js
 import {
   setupAndTeardownApp,
-  asyncIt,
+  asyncIt as it,
   startFakingXhr,
   stopFakingXhr,
   visit,
@@ -118,7 +118,7 @@ describe('my app', () => {
   setupAndTeardownApp(renderMyApp, createMemoryHistory);
 
   describe('with basic acceptance testing', () => {
-    asyncIt('shows greeting when I click the hello button on the say-hello page', () => {
+    it('shows greeting when I click the hello button on the say-hello page', () => {
       visit('/say-hello');
 
       click('.hello-button'); // This will wait for the button to show up, and then click it. Any jQuery selector will work.
@@ -136,7 +136,7 @@ describe('my app', () => {
     beforeEach(startFakingXhr);
     afterEach(stopFakingXhr);
 
-    asyncIt('displays the number of eggs we currently have on the server (using regular XHR)', () => {
+    it('displays the number of eggs we currently have on the server (using regular XHR)', () => {
       visit('/eggs');
 
       waitUntilXhrExists('GET', '/api/v1/eggs');
@@ -155,7 +155,7 @@ describe('my app', () => {
   describe('with fake fetch', () => {
     setupFakeFetchAsync();
 
-    asyncIt('shows the color of the day (using Fetch API)', () => {
+    it('shows the color of the day (using Fetch API)', () => {
       visit('/color');
 
       waitUntilFetchExists('/api/v1/color');

--- a/tests/acceptance/key-events.test.js
+++ b/tests/acceptance/key-events.test.js
@@ -1,4 +1,5 @@
 import {
+  asyncIt,
   click,
   mouseDown,
   mouseUp,
@@ -6,7 +7,6 @@ import {
   setupAsync,
   andThen,
   keyEventIn,
-  jQuery as $
 } from '../../src';
 
 describe('keyEventIn', () => {
@@ -24,7 +24,7 @@ describe('keyEventIn', () => {
     element = null;
   });
 
-  it('waits for selector to show up and then triggers a key event in it', (done) => {
+  asyncIt('waits for selector to show up and then triggers a key event in it', (done) => {
     function callback(event) {
       expect(event.bubbles).to.be.true();
       expect(event.keyCode).to.equal(39);

--- a/tests/acceptance/key-events.test.js
+++ b/tests/acceptance/key-events.test.js
@@ -1,5 +1,5 @@
 import {
-  asyncIt,
+  asyncIt as it,
   click,
   mouseDown,
   mouseUp,
@@ -24,7 +24,7 @@ describe('keyEventIn', () => {
     element = null;
   });
 
-  asyncIt('waits for selector to show up and then triggers a key event in it', (done) => {
+  it('waits for selector to show up and then triggers a key event in it', (done) => {
     function callback(event) {
       expect(event.bubbles).to.be.true();
       expect(event.keyCode).to.equal(39);

--- a/tests/acceptance/mouse-events.test.js
+++ b/tests/acceptance/mouse-events.test.js
@@ -1,4 +1,5 @@
 import {
+  asyncIt,
   click,
   mouseDown,
   mouseUp,
@@ -10,7 +11,7 @@ import {
 
 describe('Mouse Events', () => {
   describeMouseEventHelper(click, 'click', (attachElementToBody) => {
-    it('triggers mousedown and mouseup before click', () => {
+    asyncIt('triggers mousedown and mouseup before click', () => {
       const $element = $(attachElementToBody());
       const mouseDownListener = sinon.spy();
       const mouseUpListener = sinon.spy();
@@ -52,7 +53,7 @@ describe('Mouse Events', () => {
         document.body.removeChild(elementToInteractWith);
       });
 
-      it(`triggers ${eventName} event on selected element`, () => {
+      asyncIt(`triggers ${eventName} event on selected element`, () => {
         attachElementToBody();
         const spy = sinon.spy();
         $(elementToInteractWith).on(eventName, spy);
@@ -62,7 +63,7 @@ describe('Mouse Events', () => {
         });
       });
 
-      it('triggers event that bubbles', (done) => {
+      asyncIt('triggers event that bubbles', (done) => {
         const element = attachElementToBody();
         const spy = sinon.spy();
         $(element).on(eventName, e => {
@@ -72,7 +73,7 @@ describe('Mouse Events', () => {
         helperToTest(element);
       });
 
-      it('waits until element shows up before trying to interact with it', () => {
+      asyncIt('waits until element shows up before trying to interact with it', () => {
         const spy = sinon.spy();
         $(elementToInteractWith).on(eventName, spy);
         helperToTest('.element-to-interact-with');
@@ -83,7 +84,7 @@ describe('Mouse Events', () => {
         setTimeout(attachElementToBody, 500);
       });
 
-      it('takes extra options as parameters', (done) => {
+      asyncIt('takes extra options as parameters', (done) => {
         const element = attachElementToBody();
         $(element).on(eventName, e => {
           expect(e.clientX).to.equal(1337);
@@ -93,7 +94,7 @@ describe('Mouse Events', () => {
         helperToTest('.element-to-interact-with', { clientX: 1337, clientY: 1338 });
       });
 
-      it('evaluates options lazily if passed as function', (done) => {
+      asyncIt('evaluates options lazily if passed as function', (done) => {
         let screenX = 42;
 
         andThen(() => {

--- a/tests/acceptance/mouse-events.test.js
+++ b/tests/acceptance/mouse-events.test.js
@@ -1,5 +1,5 @@
 import {
-  asyncIt,
+  asyncIt as it,
   click,
   mouseDown,
   mouseUp,
@@ -11,7 +11,7 @@ import {
 
 describe('Mouse Events', () => {
   describeMouseEventHelper(click, 'click', (attachElementToBody) => {
-    asyncIt('triggers mousedown and mouseup before click', () => {
+    it('triggers mousedown and mouseup before click', () => {
       const $element = $(attachElementToBody());
       const mouseDownListener = sinon.spy();
       const mouseUpListener = sinon.spy();
@@ -53,7 +53,7 @@ describe('Mouse Events', () => {
         document.body.removeChild(elementToInteractWith);
       });
 
-      asyncIt(`triggers ${eventName} event on selected element`, () => {
+      it(`triggers ${eventName} event on selected element`, () => {
         attachElementToBody();
         const spy = sinon.spy();
         $(elementToInteractWith).on(eventName, spy);
@@ -63,7 +63,7 @@ describe('Mouse Events', () => {
         });
       });
 
-      asyncIt('triggers event that bubbles', (done) => {
+      it('triggers event that bubbles', (done) => {
         const element = attachElementToBody();
         const spy = sinon.spy();
         $(element).on(eventName, e => {
@@ -73,7 +73,7 @@ describe('Mouse Events', () => {
         helperToTest(element);
       });
 
-      asyncIt('waits until element shows up before trying to interact with it', () => {
+      it('waits until element shows up before trying to interact with it', () => {
         const spy = sinon.spy();
         $(elementToInteractWith).on(eventName, spy);
         helperToTest('.element-to-interact-with');
@@ -84,7 +84,7 @@ describe('Mouse Events', () => {
         setTimeout(attachElementToBody, 500);
       });
 
-      asyncIt('takes extra options as parameters', (done) => {
+      it('takes extra options as parameters', (done) => {
         const element = attachElementToBody();
         $(element).on(eventName, e => {
           expect(e.clientX).to.equal(1337);
@@ -94,7 +94,7 @@ describe('Mouse Events', () => {
         helperToTest('.element-to-interact-with', { clientX: 1337, clientY: 1338 });
       });
 
-      asyncIt('evaluates options lazily if passed as function', (done) => {
+      it('evaluates options lazily if passed as function', (done) => {
         let screenX = 42;
 
         andThen(() => {

--- a/tests/acceptance/test-div-dimensions.test.js
+++ b/tests/acceptance/test-div-dimensions.test.js
@@ -1,4 +1,5 @@
 import {
+  asyncIt,
   setupAndTeardownApp,
   scaleWindowWidth,
   andThen,
@@ -8,30 +9,30 @@ import {
 describe('test div dimensions', () => {
   setupAndTeardownApp(_ => {});
 
-  it('starts at 1024 x 1024', () => {
+  asyncIt('starts at 1024 x 1024', () => {
     assertTestRootWidthAndHeight(1024, 1024);
   });
 
-  it('width can be scaled down with scaleWindowWidth', () => {
+  asyncIt('width can be scaled down with scaleWindowWidth', () => {
     scaleWindowWidth(0.5);
 
     assertTestRootWidthAndHeight(512, 1024);
   });
 
-  it('width can be scaled up with scaleWindowWidth', () => {
+  asyncIt('width can be scaled up with scaleWindowWidth', () => {
     scaleWindowWidth(2);
 
     assertTestRootWidthAndHeight(2048, 1024);
   });
 
-  it('width can be scaled multiple times with scaleWindowWidth', () => {
+  asyncIt('width can be scaled multiple times with scaleWindowWidth', () => {
     scaleWindowWidth(0.5);
     scaleWindowWidth(2);
 
     assertTestRootWidthAndHeight(1024, 1024);
   });
 
-  it('triggers window resize event when calling scaleWindowWidth', () => {
+  asyncIt('triggers window resize event when calling scaleWindowWidth', () => {
     var eventListener = sinon.spy();
     $(window).resize(eventListener);
 

--- a/tests/acceptance/test-div-dimensions.test.js
+++ b/tests/acceptance/test-div-dimensions.test.js
@@ -1,5 +1,5 @@
 import {
-  asyncIt,
+  asyncIt as it,
   setupAndTeardownApp,
   scaleWindowWidth,
   andThen,
@@ -9,30 +9,30 @@ import {
 describe('test div dimensions', () => {
   setupAndTeardownApp(_ => {});
 
-  asyncIt('starts at 1024 x 1024', () => {
+  it('starts at 1024 x 1024', () => {
     assertTestRootWidthAndHeight(1024, 1024);
   });
 
-  asyncIt('width can be scaled down with scaleWindowWidth', () => {
+  it('width can be scaled down with scaleWindowWidth', () => {
     scaleWindowWidth(0.5);
 
     assertTestRootWidthAndHeight(512, 1024);
   });
 
-  asyncIt('width can be scaled up with scaleWindowWidth', () => {
+  it('width can be scaled up with scaleWindowWidth', () => {
     scaleWindowWidth(2);
 
     assertTestRootWidthAndHeight(2048, 1024);
   });
 
-  asyncIt('width can be scaled multiple times with scaleWindowWidth', () => {
+  it('width can be scaled multiple times with scaleWindowWidth', () => {
     scaleWindowWidth(0.5);
     scaleWindowWidth(2);
 
     assertTestRootWidthAndHeight(1024, 1024);
   });
 
-  asyncIt('triggers window resize event when calling scaleWindowWidth', () => {
+  it('triggers window resize event when calling scaleWindowWidth', () => {
     var eventListener = sinon.spy();
     $(window).resize(eventListener);
 

--- a/tests/acceptance/touch-events.test.js
+++ b/tests/acceptance/touch-events.test.js
@@ -1,5 +1,5 @@
 import {
-  asyncIt,
+  asyncIt as it,
   touchStart,
   touchMove,
   touchCancel,
@@ -35,7 +35,7 @@ describe('Touch Events', () => {
           document.body.removeChild(elementToInteractWith);
         });
     
-        asyncIt(`triggers ${eventName} event on selected element`, () => {
+        it(`triggers ${eventName} event on selected element`, () => {
           attachElementToBody();
           const spy = sinon.spy();
           elementToInteractWith.addEventListener(eventName, spy);
@@ -45,7 +45,7 @@ describe('Touch Events', () => {
           });
         });
 
-        asyncIt('triggers event that bubbles', (done) => {
+        it('triggers event that bubbles', (done) => {
           const element = attachElementToBody();
           const spy = sinon.spy();
           $(element).on(eventName, e => {
@@ -55,7 +55,7 @@ describe('Touch Events', () => {
           helperToTest(element);
         });
     
-        asyncIt('waits until element shows up before trying to interact with it', () => {
+        it('waits until element shows up before trying to interact with it', () => {
           const spy = sinon.spy();
           $(elementToInteractWith).on(eventName, spy);
           helperToTest('.element-to-interact-with');
@@ -66,7 +66,7 @@ describe('Touch Events', () => {
           setTimeout(attachElementToBody, 500);
         });
     
-        asyncIt('takes extra options as parameters', (done) => {
+        it('takes extra options as parameters', (done) => {
           const element = attachElementToBody();
           const handleEvent = e => {
             expect(e.touches[0].clientX).to.equal(1337);
@@ -96,7 +96,7 @@ describe('Touch Events', () => {
           });
         });
     
-        asyncIt('evaluates options lazily if passed as function', (done) => {
+        it('evaluates options lazily if passed as function', (done) => {
           let screenX = 42;
     
           andThen(() => {

--- a/tests/acceptance/touch-events.test.js
+++ b/tests/acceptance/touch-events.test.js
@@ -1,4 +1,5 @@
 import {
+  asyncIt,
   touchStart,
   touchMove,
   touchCancel,
@@ -34,7 +35,7 @@ describe('Touch Events', () => {
           document.body.removeChild(elementToInteractWith);
         });
     
-        it(`triggers ${eventName} event on selected element`, () => {
+        asyncIt(`triggers ${eventName} event on selected element`, () => {
           attachElementToBody();
           const spy = sinon.spy();
           elementToInteractWith.addEventListener(eventName, spy);
@@ -44,7 +45,7 @@ describe('Touch Events', () => {
           });
         });
 
-        it('triggers event that bubbles', (done) => {
+        asyncIt('triggers event that bubbles', (done) => {
           const element = attachElementToBody();
           const spy = sinon.spy();
           $(element).on(eventName, e => {
@@ -54,7 +55,7 @@ describe('Touch Events', () => {
           helperToTest(element);
         });
     
-        it('waits until element shows up before trying to interact with it', () => {
+        asyncIt('waits until element shows up before trying to interact with it', () => {
           const spy = sinon.spy();
           $(elementToInteractWith).on(eventName, spy);
           helperToTest('.element-to-interact-with');
@@ -65,7 +66,7 @@ describe('Touch Events', () => {
           setTimeout(attachElementToBody, 500);
         });
     
-        it('takes extra options as parameters', (done) => {
+        asyncIt('takes extra options as parameters', (done) => {
           const element = attachElementToBody();
           const handleEvent = e => {
             expect(e.touches[0].clientX).to.equal(1337);
@@ -95,7 +96,7 @@ describe('Touch Events', () => {
           });
         });
     
-        it('evaluates options lazily if passed as function', (done) => {
+        asyncIt('evaluates options lazily if passed as function', (done) => {
           let screenX = 42;
     
           andThen(() => {

--- a/tests/acceptance/visit.test.js
+++ b/tests/acceptance/visit.test.js
@@ -1,9 +1,9 @@
-import { setupAsync, visit, andThen, setupAndTeardownApp } from '../../src';
+import { asyncIt, setupAsync, visit, andThen, setupAndTeardownApp } from '../../src';
 
 describe('visit', () => {
   describe('when setupAndTeardownApp has not been called', () => {
     setupAsync();
-    it('throws', () => {
+    asyncIt('throws', () => {
       expect(() => {
         visit('/some/path');
       }).to.throw('acast-test-helpers#visit(): You cannot use visit() unless you pass a valid createHistory function to setupAndTeardownApp() at the root of the appropriate describe()!');
@@ -17,13 +17,13 @@ describe('visit', () => {
     });
     setupAndTeardownApp(_ => {}, createHistory);
 
-    it('does not throw', () => {
+    asyncIt('does not throw', () => {
       expect(() => {
         visit('/some/path');
       }).to.not.throw();
     });
 
-    it('pushes path to history', () => {
+    asyncIt('pushes path to history', () => {
       visit('/this/path');
       andThen(() => expect(pushSpy).to.have.been.calledWith('/this/path'));
     })

--- a/tests/acceptance/visit.test.js
+++ b/tests/acceptance/visit.test.js
@@ -1,9 +1,9 @@
-import { asyncIt, setupAsync, visit, andThen, setupAndTeardownApp } from '../../src';
+import { asyncIt as it, setupAsync, visit, andThen, setupAndTeardownApp } from '../../src';
 
 describe('visit', () => {
   describe('when setupAndTeardownApp has not been called', () => {
     setupAsync();
-    asyncIt('throws', () => {
+    it('throws', () => {
       expect(() => {
         visit('/some/path');
       }).to.throw('acast-test-helpers#visit(): You cannot use visit() unless you pass a valid createHistory function to setupAndTeardownApp() at the root of the appropriate describe()!');
@@ -17,13 +17,13 @@ describe('visit', () => {
     });
     setupAndTeardownApp(_ => {}, createHistory);
 
-    asyncIt('does not throw', () => {
+    it('does not throw', () => {
       expect(() => {
         visit('/some/path');
       }).to.not.throw();
     });
 
-    asyncIt('pushes path to history', () => {
+    it('pushes path to history', () => {
       visit('/this/path');
       andThen(() => expect(pushSpy).to.have.been.calledWith('/this/path'));
     })

--- a/tests/acceptance/waitUntilDisappears.test.js
+++ b/tests/acceptance/waitUntilDisappears.test.js
@@ -1,4 +1,4 @@
-import { asyncIt, setupAsync, andThen, waitUntilDisappears } from '../../src';
+import { asyncIt as it, setupAsync, andThen, waitUntilDisappears } from '../../src';
 
 describe('waitUntilDisappears', () => {
   setupAsync();
@@ -6,7 +6,7 @@ describe('waitUntilDisappears', () => {
   const label = document.createElement('label');
   label.innerHTML = 'foobar';
 
-  asyncIt('resolve when the object disappears after having showed', (done) => {
+  it('resolve when the object disappears after having showed', (done) => {
     let callback = sinon.spy();
 
     waitUntilDisappears('label:contains("foobar")');

--- a/tests/acceptance/waitUntilDisappears.test.js
+++ b/tests/acceptance/waitUntilDisappears.test.js
@@ -1,4 +1,4 @@
-import { setupAsync, andThen, waitUntilDisappears } from '../../src';
+import { asyncIt, setupAsync, andThen, waitUntilDisappears } from '../../src';
 
 describe('waitUntilDisappears', () => {
   setupAsync();
@@ -6,7 +6,7 @@ describe('waitUntilDisappears', () => {
   const label = document.createElement('label');
   label.innerHTML = 'foobar';
 
-  it('resolve when the object disappears after having showed', (done) => {
+  asyncIt('resolve when the object disappears after having showed', (done) => {
     let callback = sinon.spy();
 
     waitUntilDisappears('label:contains("foobar")');

--- a/tests/acceptance/waitUntilExists.test.js
+++ b/tests/acceptance/waitUntilExists.test.js
@@ -1,4 +1,4 @@
-import { asyncIt, setupAsync, andThen, waitUntilExists } from '../../src';
+import { asyncIt as it, setupAsync, andThen, waitUntilExists } from '../../src';
 
 describe('waitUntilExists', () => {
   setupAsync();
@@ -10,7 +10,7 @@ describe('waitUntilExists', () => {
     document.body.removeChild(label);
   });
 
-  asyncIt('resolves with a jquery object of the selector when it exists', () => {
+  it('resolves with a jquery object of the selector when it exists', () => {
     setTimeout(() => {
       label.innerHTML = 'foobar';
       document.body.appendChild(label);

--- a/tests/acceptance/waitUntilExists.test.js
+++ b/tests/acceptance/waitUntilExists.test.js
@@ -1,4 +1,4 @@
-import { setupAsync, andThen, waitUntilExists } from '../../src';
+import { asyncIt, setupAsync, andThen, waitUntilExists } from '../../src';
 
 describe('waitUntilExists', () => {
   setupAsync();
@@ -10,7 +10,7 @@ describe('waitUntilExists', () => {
     document.body.removeChild(label);
   });
 
-  it('resolves with a jquery object of the selector when it exists', () => {
+  asyncIt('resolves with a jquery object of the selector when it exists', () => {
     setTimeout(() => {
       label.innerHTML = 'foobar';
       document.body.appendChild(label);

--- a/tests/async/andThen.test.js
+++ b/tests/async/andThen.test.js
@@ -1,18 +1,24 @@
-import { setupAsync, andThen } from '../../src';
+import { asyncIt, setupAsync, andThen } from '../../src';
 
 describe('andThen', () => {
   describe('without having called setupAsync()', () => {
-    it('throws informative error', () => {
+    asyncIt('throws informative error', () => {
       expect(() => {
         andThen();
-      }).to.throw('You cannot use andThen() unless you call setupAsync() at the root of the appropriate describe()!');
+      }).to.throw('acast-test-helpers#andThen(): You cannot use the async functions unless you call setupAsync() at the root of the appropriate describe()!');
     });
   });
 
   describe('after having called setupAsync', () => {
     setupAsync();
 
-    it('chains off of a global promise (behind the curtains)', () => {
+    it('throws if not used inside `asyncIt`', () => {
+      expect(() => {
+        andThen();
+      }).to.throw('acast-test-helpers#andThen(): You can only use the async functions from acast-test-helpers inside asyncIt.');
+    });
+
+    asyncIt('chains off of a global promise (behind the curtains)', () => {
       let sequence = '0';
 
       andThen(() => {
@@ -32,15 +38,13 @@ describe('andThen', () => {
       expect(sequence).to.equal('0');
     });
 
-    it('NOTE: can be nested, but the ordering might seem unintuitive', (done) => {
+    asyncIt('cannot be nested', () => {
       let sequence = '0';
       andThen(() => {
         sequence += '1';
-        andThen(() => {
-          sequence += '3';
-          expect(sequence).to.equal('0123');
-          done();
-        });
+        expect(() => {
+          andThen();
+        }).to.throw('Also note that you cannot nest calls to async functions.');
       });
 
       andThen(() => {

--- a/tests/async/asyncIt.test.js
+++ b/tests/async/asyncIt.test.js
@@ -1,0 +1,9 @@
+import { asyncIt, setupAsync } from '../../src';
+
+describe('asyncIt', () => {
+  setupAsync();
+
+  asyncIt('consolidates returned promise with global test promise', () => {
+    return Promise.resolve();
+  });
+});

--- a/tests/async/waitMillis.test.js
+++ b/tests/async/waitMillis.test.js
@@ -1,9 +1,9 @@
-import { asyncIt, setupAsync, waitMillis, andThen } from '../../src';
+import { asyncIt as it, setupAsync, waitMillis, andThen } from '../../src';
 
 describe('waitMillis', () => {
   setupAsync();
 
-  asyncIt('waits the specified amount of milliseconds', () => {
+  it('waits the specified amount of milliseconds', () => {
     const start = Date.now();
 
     waitMillis(1337);

--- a/tests/async/waitMillis.test.js
+++ b/tests/async/waitMillis.test.js
@@ -1,9 +1,9 @@
-import { setupAsync, waitMillis, andThen } from '../../src';
+import { asyncIt, setupAsync, waitMillis, andThen } from '../../src';
 
 describe('waitMillis', () => {
   setupAsync();
 
-  it('waits the specified amount of milliseconds', () => {
+  asyncIt('waits the specified amount of milliseconds', () => {
     const start = Date.now();
 
     waitMillis(1337);

--- a/tests/async/waitUntil.test.js
+++ b/tests/async/waitUntil.test.js
@@ -1,8 +1,8 @@
-import { asyncIt, setupAsync, waitUntil, andThen } from '../../src';
+import { asyncIt as it, setupAsync, waitUntil, andThen } from '../../src';
 
 describe('waitUntil', () => {
   setupAsync();
-  asyncIt('resolves when predicate returns true', () => {
+  it('resolves when predicate returns true', () => {
     let value = false;
 
     setTimeout(() => {
@@ -16,21 +16,21 @@ describe('waitUntil', () => {
     });
   });
 
-  asyncIt.skip('shuts down predicate after timeout', () => {
+  it.skip('shuts down predicate after timeout', () => {
     waitUntil(() => {
       console.log('this should stop logging after test times out');
     });
   });
 
-  asyncIt.skip('handles expections, returning the message of the last one upon timeout', () => {
+  it.skip('handles expections, returning the message of the last one upon timeout', () => {
     waitUntil(() => expect('foo').to.equal('bar'));
   });
 
-  asyncIt.skip('handles expections, returning the lazily evaluated message from the optional function passed', () => {
+  it.skip('handles expections, returning the lazily evaluated message from the optional function passed', () => {
     waitUntil(() => false, () => 13 + 37);
   });
 
-  asyncIt('handles exceptions, silently treating them as falsy return values', () => {
+  it('handles exceptions, silently treating them as falsy return values', () => {
     let value = false;
 
     setTimeout(() => {
@@ -47,7 +47,7 @@ describe('waitUntil', () => {
     });
   });
 
-  asyncIt('can be used solely to wait for an expectation to be true', () => {
+  it('can be used solely to wait for an expectation to be true', () => {
     let fruit = 'apple';
 
     setTimeout(() => {
@@ -57,7 +57,7 @@ describe('waitUntil', () => {
     waitUntil(() => expect(fruit).to.equal('banana'));
   });
 
-  asyncIt('resolves when predicate returns truthy string', () => {
+  it('resolves when predicate returns truthy string', () => {
     let value = false;
 
     setTimeout(() => {
@@ -67,7 +67,7 @@ describe('waitUntil', () => {
     waitUntil(() => value);
   });
 
-  asyncIt('resolves with the truthy value', () => {
+  it('resolves with the truthy value', () => {
     waitUntil(() => 'the value, yo');
 
     andThen((parameter) => {
@@ -75,7 +75,7 @@ describe('waitUntil', () => {
     });
   });
 
-  asyncIt('passes along the previously resolved value to the predicate', () => {
+  it('passes along the previously resolved value to the predicate', () => {
     andThen(() => {
       return 'the resolved value';
     });
@@ -87,7 +87,7 @@ describe('waitUntil', () => {
     })
   });
 
-  asyncIt('passes along the previously resolved value to each iteration of the predicate', () => {
+  it('passes along the previously resolved value to each iteration of the predicate', () => {
     const obj = { value: false };
 
     setTimeout(() => {
@@ -101,7 +101,7 @@ describe('waitUntil', () => {
     waitUntil(theResolvedObject => expect(theResolvedObject.value).to.be.true());
   });
 
-  asyncIt('polls at every hundred milliseconds', (done) => {
+  it('polls at every hundred milliseconds', (done) => {
     let value = false;
     let didComplete = false;
 
@@ -126,7 +126,7 @@ describe('waitUntil', () => {
     }, 1500);
   });
 
-  asyncIt('makes first poll immediately', () => {
+  it('makes first poll immediately', () => {
     let value = true;
 
     setTimeout(() => {

--- a/tests/async/waitUntil.test.js
+++ b/tests/async/waitUntil.test.js
@@ -1,8 +1,8 @@
-import { setupAsync, waitUntil, andThen } from '../../src';
+import { asyncIt, setupAsync, waitUntil, andThen } from '../../src';
 
 describe('waitUntil', () => {
   setupAsync();
-  it('resolves when predicate returns true', () => {
+  asyncIt('resolves when predicate returns true', () => {
     let value = false;
 
     setTimeout(() => {
@@ -16,13 +16,21 @@ describe('waitUntil', () => {
     });
   });
 
-  it.skip('shuts down predicate after timeout', () => {
+  asyncIt.skip('shuts down predicate after timeout', () => {
     waitUntil(() => {
       console.log('this should stop logging after test times out');
     });
   });
 
-  it('handles exceptions, silently treating them as falsy return values', () => {
+  asyncIt.skip('handles expections, returning the message of the last one upon timeout', () => {
+    waitUntil(() => expect('foo').to.equal('bar'));
+  });
+
+  asyncIt.skip('handles expections, returning the lazily evaluated message from the optional function passed', () => {
+    waitUntil(() => false, () => 13 + 37);
+  });
+
+  asyncIt('handles exceptions, silently treating them as falsy return values', () => {
     let value = false;
 
     setTimeout(() => {
@@ -39,7 +47,7 @@ describe('waitUntil', () => {
     });
   });
 
-  it('can be used solely to wait for an expectation to be true', () => {
+  asyncIt('can be used solely to wait for an expectation to be true', () => {
     let fruit = 'apple';
 
     setTimeout(() => {
@@ -49,7 +57,7 @@ describe('waitUntil', () => {
     waitUntil(() => expect(fruit).to.equal('banana'));
   });
 
-  it('resolves when predicate returns truthy string', () => {
+  asyncIt('resolves when predicate returns truthy string', () => {
     let value = false;
 
     setTimeout(() => {
@@ -59,7 +67,7 @@ describe('waitUntil', () => {
     waitUntil(() => value);
   });
 
-  it('resolves with the truthy value', () => {
+  asyncIt('resolves with the truthy value', () => {
     waitUntil(() => 'the value, yo');
 
     andThen((parameter) => {
@@ -67,7 +75,7 @@ describe('waitUntil', () => {
     });
   });
 
-  it('passes along the previously resolved value to the predicate', () => {
+  asyncIt('passes along the previously resolved value to the predicate', () => {
     andThen(() => {
       return 'the resolved value';
     });
@@ -79,7 +87,7 @@ describe('waitUntil', () => {
     })
   });
 
-  it('passes along the previously resolved value to each iteration of the predicate', () => {
+  asyncIt('passes along the previously resolved value to each iteration of the predicate', () => {
     const obj = { value: false };
 
     setTimeout(() => {
@@ -93,7 +101,7 @@ describe('waitUntil', () => {
     waitUntil(theResolvedObject => expect(theResolvedObject.value).to.be.true());
   });
 
-  it('polls at every hundred milliseconds', (done) => {
+  asyncIt('polls at every hundred milliseconds', (done) => {
     let value = false;
     let didComplete = false;
 
@@ -118,7 +126,7 @@ describe('waitUntil', () => {
     }, 1500);
   });
 
-  it('makes first poll immediately', () => {
+  asyncIt('makes first poll immediately', () => {
     let value = true;
 
     setTimeout(() => {

--- a/tests/async/waitUntilChange.test.js
+++ b/tests/async/waitUntilChange.test.js
@@ -1,8 +1,8 @@
-import { asyncIt, setupAsync, waitUntil, waitUntilChange, andThen } from '../../src';
+import { asyncIt as it, setupAsync, waitUntil, waitUntilChange, andThen } from '../../src';
 
 describe('waitUntilChange', () => {
   setupAsync();
-  asyncIt('moves on when the predicate returns a different value than the first call', () => {
+  it('moves on when the predicate returns a different value than the first call', () => {
     let value = 4;
 
     setTimeout(() => {
@@ -14,7 +14,7 @@ describe('waitUntilChange', () => {
     andThen(resolvedValue => expect(resolvedValue).to.equal(0));
   });
 
-  asyncIt('passes the chained value to predicate', () => {
+  it('passes the chained value to predicate', () => {
     const obj = { value: 4 };
 
     setTimeout(() => {

--- a/tests/async/waitUntilChange.test.js
+++ b/tests/async/waitUntilChange.test.js
@@ -1,8 +1,8 @@
-import { setupAsync, waitUntil, waitUntilChange, andThen } from '../../src';
+import { asyncIt, setupAsync, waitUntil, waitUntilChange, andThen } from '../../src';
 
 describe('waitUntilChange', () => {
   setupAsync();
-  it('moves on when the predicate returns a different value than the first call', () => {
+  asyncIt('moves on when the predicate returns a different value than the first call', () => {
     let value = 4;
 
     setTimeout(() => {
@@ -14,7 +14,7 @@ describe('waitUntilChange', () => {
     andThen(resolvedValue => expect(resolvedValue).to.equal(0));
   });
 
-  it('passes the chained value to predicate', () => {
+  asyncIt('passes the chained value to predicate', () => {
     const obj = { value: 4 };
 
     setTimeout(() => {

--- a/tests/fetch/fetch-async.test.js
+++ b/tests/fetch/fetch-async.test.js
@@ -1,9 +1,9 @@
-import { andThen, setupFakeFetchAsync, waitUntilFetchExists } from '../../src';
+import { asyncIt, andThen, setupFakeFetchAsync, waitUntilFetchExists } from '../../src';
 
 describe('fake fetch async', () => {
   setupFakeFetchAsync();
 
-  it('resolves with the promise-looking object', () => {
+  asyncIt('resolves with the promise-looking object', () => {
     waitUntilFetchExists('/some/path');
 
     andThen(fetchRequest => {

--- a/tests/fetch/fetch-async.test.js
+++ b/tests/fetch/fetch-async.test.js
@@ -1,9 +1,9 @@
-import { asyncIt, andThen, setupFakeFetchAsync, waitUntilFetchExists } from '../../src';
+import { asyncIt as it, andThen, setupFakeFetchAsync, waitUntilFetchExists } from '../../src';
 
 describe('fake fetch async', () => {
   setupFakeFetchAsync();
 
-  asyncIt('resolves with the promise-looking object', () => {
+  it('resolves with the promise-looking object', () => {
     waitUntilFetchExists('/some/path');
 
     andThen(fetchRequest => {

--- a/tests/xhr/xhr.test.js
+++ b/tests/xhr/xhr.test.js
@@ -1,4 +1,4 @@
-import { setupAsync, andThen, startFakingXhr, stopFakingXhr, findXhr, waitUntilXhrExists } from '../../src';
+import { asyncIt, setupAsync, andThen, startFakingXhr, stopFakingXhr, findXhr, waitUntilXhrExists } from '../../src';
 
 describe('fake xhr', () => {
   describe('findXhrRequest', () => {
@@ -44,7 +44,7 @@ describe('fake xhr', () => {
   describe('waitUntilXhrExists', () => {
     setupAsync();
 
-    it('resolves when the request is found', () => {
+    asyncIt('resolves when the request is found', () => {
       startFakingXhr();
       waitUntilXhrExists('POST', '/some/endpoint/path');
       andThen(request => {

--- a/tests/xhr/xhr.test.js
+++ b/tests/xhr/xhr.test.js
@@ -1,4 +1,4 @@
-import { asyncIt, setupAsync, andThen, startFakingXhr, stopFakingXhr, findXhr, waitUntilXhrExists } from '../../src';
+import { asyncIt as it, setupAsync, andThen, startFakingXhr, stopFakingXhr, findXhr, waitUntilXhrExists } from '../../src';
 
 describe('fake xhr', () => {
   describe('findXhrRequest', () => {
@@ -44,7 +44,7 @@ describe('fake xhr', () => {
   describe('waitUntilXhrExists', () => {
     setupAsync();
 
-    asyncIt('resolves when the request is found', () => {
+    it('resolves when the request is found', () => {
       startFakingXhr();
       waitUntilXhrExists('POST', '/some/endpoint/path');
       andThen(request => {


### PR DESCRIPTION
A big problem with the usability of this repo has been that all the asynchronous error handling has been taking place in an `afterEach` function. This has lead the tests to immediately `pass`, but then possibly fail or time out in the `afterEach` step. This has been confusing in many ways: The error has not been shown having happened in the test, the visual impression has been that there has been a passing test and a failing one at the same time (for the same test case) and, maybe most importantly, no following tests in the same `describe` as the failing one has been allowed to continue since the failure took place in the `afterEach`. 

This fixes all of that.

The only thing the developer will have to change is to use the new `asyncIt` instead of the regular `it`. This will be enforced as the asynchonous helper methods will throw errors if used outside an `asyncIt`. I believe this change will increase the usability of this library tremendously, but we will see.