### PR TITLE
Loosen arguments for respondWithJson

### DIFF
--- a/src/xhr/stubber.js
+++ b/src/xhr/stubber.js
@@ -36,12 +36,17 @@ function FakeRequest() {
   FakeXMLHttpRequest.call(this);
   fakehr.addRequest(this);
 
-  this.respondWithJson = (statusCode, payload) =>
+  this.respondWithJson = (statusCode=200, payload={}) => {
+    if (typeof statusCode !== 'number') {
+      payload = statusCode;
+      statusCode = 200;
+    }
     this.respond(
       statusCode,
       { 'Content-Type': 'application/json' },
       JSON.stringify(payload)
-    );
+    )
+  };
 
   this.respondWithOctetStream = (statusCode, buffer) => {
     this.responseType = 'arraybuffer';

--- a/tests/xhr/xhr.test.js
+++ b/tests/xhr/xhr.test.js
@@ -57,6 +57,55 @@ describe('fake xhr', () => {
       }, 1000);
     });
   });
+
+  describe('request object', () => {
+    beforeEach(startFakingXhr);
+    afterEach(stopFakingXhr);
+
+    describe('respond', () => {
+      it('can be used to respond manually with status code and headers', () => {
+        const request = sendRequest('GET', '/some/endpoint');
+        request.respond(200, {'Some-Header': 'some-header-value'}, JSON.stringify({someBodyKey: 'someBodyValue'}));
+
+        expect(request.readyState).to.equal(4);
+        expect(request.status).to.equal(200);
+        expect(request.responseHeaders).to.deep.equal({'Some-Header': 'some-header-value'});
+        expect(JSON.parse(request.responseText)).to.deep.equal({someBodyKey: 'someBodyValue'});
+      });
+    });
+
+    describe('respondWithJson', () => {
+      it('can be used as convenience method to send JSON without having to stringify body and set JSON header', () => {
+        const request = sendRequest('GET', '/some/endpoint');
+        request.respondWithJson(200, {someBodyKey: 'someBodyValue'});
+
+        expect(request.readyState).to.equal(4);
+        expect(request.status).to.equal(200);
+        expect(request.responseHeaders).to.deep.equal({'Content-Type': 'application/json'});
+        expect(JSON.parse(request.responseText)).to.deep.equal({someBodyKey: 'someBodyValue'});
+      });
+
+      it('sets status to 200 by default', () => {
+        const request = sendRequest('GET', '/some/endpoint');
+        request.respondWithJson({someBodyKey: 'someBodyValue'});
+
+        expect(request.readyState).to.equal(4);
+        expect(request.status).to.equal(200);
+        expect(request.responseHeaders).to.deep.equal({'Content-Type': 'application/json'});
+        expect(JSON.parse(request.responseText)).to.deep.equal({someBodyKey: 'someBodyValue'});
+      });
+
+      it('can be used to simply send status', () => {
+        const request = sendRequest('GET', '/some/endpoint');
+        request.respondWithJson(404);
+
+        expect(request.readyState).to.equal(4);
+        expect(request.status).to.equal(404);
+        expect(request.responseHeaders).to.deep.equal({'Content-Type': 'application/json'});
+        expect(JSON.parse(request.responseText)).to.deep.equal({});
+      });
+    });
+  });
 });
 
 


### PR DESCRIPTION
Closes https://trello.com/c/kQ22Bi9T/390-acast-test-helpers-respondwithjson-should-throw-if-first-argument-is-not-a-number.

Instead of throwing, I have enabled omitting the status code, defaulting to 200.