### PR TITLE
Make `fillIn` throw helpful exceptions if used wrongly

### DIFF
--- a/src/acceptance.js
+++ b/src/acceptance.js
@@ -296,11 +296,19 @@ export function fillIn(selector, value) {
       potential => target instanceof potential
     );
 
+    if (!inputClass) {
+      throw new Error(`acast-test-helpers#fillIn(): Selector '${selector}' matched invalid type. fillIn() can only be used on elements of type 'input', 'select' or 'textarea'!`);
+    }
+
     const originalValueSetter = Object.getOwnPropertyDescriptor(
       inputClass.prototype,
       'value'
     ).set; // https://github.com/cypress-io/cypress/issues/536#issuecomment-311694226
     originalValueSetter.call(target, value);
+
+    if (value && target.value !== value.toString()) {
+      throw new Error(`acast-test-helpers#fillIn(): Failed to set value '${value}' on element matched by selector '${selector}'! If it's a <select>, make sure the filled in value is one of the options.`);
+    }
 
     target.dispatchEvent(new Event('input', { bubbles: true }));
     target.dispatchEvent(new Event('change', { bubbles: true }));

--- a/tests/acceptance/fillIn.test.js
+++ b/tests/acceptance/fillIn.test.js
@@ -1,0 +1,77 @@
+import { jQuery as $, fillIn, asyncIt as it, setupAsync, andThen, waitUntilExists } from '../../src';
+
+describe('fillIn', () => {
+  setupAsync();
+
+  let input;
+  let changeSpy;
+
+  beforeEach(() => {
+    input = null;
+    changeSpy = sinon.spy();
+  });
+
+  afterEach(() => {
+    if (input) {
+      input.remove();
+    }
+  });
+
+  ['input', 'textarea'].forEach(textInputType => {
+    it(`waits for input of type ${textInputType} and sets value of it`, () => {
+      givenInput($(document.createElement(textInputType)));
+
+      fillIn('[data-test-id="input"]', 'foobar');
+
+      andThen(() => {
+        expect(input.val()).to.equal('foobar');
+        expect(changeSpy).to.have.been.calledOnce();
+      });
+    });
+  });
+
+  it('can set value of select', () => {
+    givenSelectWithValues([1, 2, 3]);
+
+    fillIn('[data-test-id="input"]', 2);
+
+    andThen(() => {
+      expect(input.val()).to.equal('2');
+      expect(changeSpy).to.have.been.calledOnce();
+    });
+  });
+
+  it.skip('throws if passed invalid value for select', () => {
+    givenSelectWithValues([1, 2, 3]);
+
+    fillIn('[data-test-id="input"]', 'invalid-value');
+
+    // Should throw with an error stating that value could not be set. 
+  });
+
+  it.skip('throws if applied to non-input', () => {
+    givenInput($('<div>'));
+
+    fillIn('[data-test-id="input"]', 'some-text');
+
+    // Should throw with an error stating that selector has to match an input element.
+  });
+
+  function givenSelectWithValues(values) {
+    const select = $('<select>');
+    values.forEach((value) => {
+      select.append($('<option>').attr('value', value).text(`label for ${value}`));
+    });
+
+    givenInput(select);
+  }
+
+  function givenInput(inputToTest) {
+    input = inputToTest;
+    input.attr('data-test-id', 'input');
+    input.on('change', changeSpy);
+    setTimeout(() => {
+      input.appendTo('body');
+    }, 10);
+  }
+});


### PR DESCRIPTION
Closes https://trello.com/c/AuOsmjH5/330-acast-test-helpers-using-fillin-on-a-select-for-a-nonexistent-value-will-trigger-value-change-with-empty-value.

The reason for skipping some tests is that those tests throw and the error message needs to be verified manually. It kind of sucks but I have not been able to come up with a good way to automatically verify that the helpers should make the tests fail. 